### PR TITLE
feat: ドラッグ移動・物理投げ・衝突判定 (#8, #10)

### DIFF
--- a/mascot/lib/mascot_widget.dart
+++ b/mascot/lib/mascot_widget.dart
@@ -337,6 +337,18 @@ class _MascotWidgetState extends State<MascotWidget>
                             _jumpController.forward(from: 0);
                             _expressionService.expressRandom();
                           },
+                          onPanStart: _isWander
+                              ? (_) => _wander!.startDrag()
+                              : null,
+                          onPanUpdate: _isWander
+                              ? (details) => _wander!.updateDrag(details.delta)
+                              : null,
+                          onPanEnd: _isWander
+                              ? (details) => _wander!.endDrag(
+                                    details.velocity.pixelsPerSecond.dx,
+                                    details.velocity.pixelsPerSecond.dy,
+                                  )
+                              : null,
                           child: _buildCharacter(),
                         ),
                       ),


### PR DESCRIPTION
## Summary
- **#8**: ワンダーモードでドラッグ移動+物理演算投げ（慣性・重力・壁バウンス）を実装
- **#10**: AABB衝突判定を追加し、マスコット同士の重なりを解決

## Test plan
- [ ] ワンダーモードのキャラをドラッグで移動できるか確認
- [ ] 投げると慣性で動き、重力で着地するか確認
- [ ] 壁でバウンスするか確認
- [ ] 着地後に自動歩行が再開するか確認

Closes #8, Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)