### PR TITLE
feat: マスコットの白フチ＋黒輪郭モード追加

### DIFF
--- a/mascot/lib/main.dart
+++ b/mascot/lib/main.dart
@@ -70,6 +70,7 @@ class _AppConfig {
   final double? width;
   final double? height;
   final bool wander;
+  final bool outline;
 
   const _AppConfig({
     this.modelsDir,
@@ -79,6 +80,7 @@ class _AppConfig {
     this.width,
     this.height,
     this.wander = false,
+    this.outline = false,
   });
 }
 
@@ -91,6 +93,7 @@ _AppConfig _parseArgs(List<String> args) {
   double? width;
   double? height;
   bool wander = false;
+  bool outline = false;
 
   for (var i = 0; i < args.length; i++) {
     switch (args[i]) {
@@ -110,6 +113,8 @@ _AppConfig _parseArgs(List<String> args) {
         wander = true;
       case '--no-wander':
         wander = false;
+      case '--outline':
+        outline = true;
     }
   }
 
@@ -121,6 +126,7 @@ _AppConfig _parseArgs(List<String> args) {
     width: width,
     height: height,
     wander: wander,
+    outline: outline,
   );
 }
 
@@ -318,6 +324,7 @@ class _MascotAppState extends State<MascotApp> {
         home: MascotWidget(
           controller: _controller,
           wanderController: _wanderController,
+          outlineEnabled: widget.config.outline,
         ),
       );
     }
@@ -334,7 +341,10 @@ class _MascotAppState extends State<MascotApp> {
           SizedBox(
             width: _mainWidth,
             height: _windowHeight,
-            child: MascotWidget(controller: _controller),
+            child: MascotWidget(
+              controller: _controller,
+              outlineEnabled: widget.config.outline,
+            ),
           ),
           for (var i = 0; i < _children.length; i++)
             SizedBox(
@@ -343,6 +353,7 @@ class _MascotAppState extends State<MascotApp> {
               child: MascotWidget(
                 key: ValueKey(_children[i].signalDir),
                 controller: _children[i].controller,
+                outlineEnabled: widget.config.outline,
                 onDismissComplete: () => _removeChildBySignalDir(_children[i].signalDir),
               ),
             ),


### PR DESCRIPTION
## Summary
- `--outline` CLIフラグで白フチ＋黒輪郭描画モードを追加
- `ImageFilter.dilate` で黒(4px)→白(2px)→元画像の3層スタックで輪郭を表現
- `MascotWidget`に`outlineEnabled`パラメータ追加、`_AppConfig`に`--outline`フラグ追加

## Test plan
- [ ] `flutter run -d macos --dart-entrypoint-args '--outline'` で白フチ＋黒輪郭が表示される
- [ ] `--outline` なしで通常表示される
- [ ] ワンダーモード(`--wander --outline`)でも正しく表示される

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)