### PR TITLE
feat: きゅうくらりんスキル追加

### DIFF
--- a/.claude/skills/kyuuklarin/SKILL.md
+++ b/.claude/skills/kyuuklarin/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: kyuuklarin
+description: きゅうくらりんスキルを追加
+user_invocable: true
+---
+
+# /kyuuklarin - きゅうくらりん
+
+マスコットがきゅうくらりんっぽくくるくる回転して元に戻る楽しいスキル。
+
+## Usage
+
+```
+/kyuuklarin
+```
+
+## Steps
+
+1. Write the kyuuklarin signal file to trigger the animation
+
+```bash
+python3 -c "
+from pathlib import Path
+signal_dir = Path.home() / '.claude' / 'utsutsu-code'
+signal_dir.mkdir(parents=True, exist_ok=True)
+signal_path = signal_dir / 'mascot_kyuuklarin'
+signal_path.write_text('')
+print('きゅうくらりん♪')
+"
+```
+
+2. Report to the user that the animation was triggered
+
+The mascot will:
+- Spin around 2 times with a scaling effect
+- Show the Singing expression with "きゅうくらりん♪" message
+- Return to normal after ~1.5 seconds

--- a/mascot/lib/mascot_controller.dart
+++ b/mascot/lib/mascot_controller.dart
@@ -10,18 +10,23 @@ class MascotController extends ChangeNotifier {
   final String _signalPath;
   final String _listeningPath;
   final String _dismissPath;
+  final String _kyuuklarinPath;
   late final ModelConfig _modelConfig;
 
   bool _isSpeaking = false;
   bool _isListening = false;
   bool _directExpression = false;
   bool _dismissed = false;
+  bool _kyuuklarin = false;
   String _message = '';
   String? _currentEmotion;
   Map<String, double> _wanderOverrides = {};
 
   /// True when a dismiss signal has been received.
   bool get isDismissed => _dismissed;
+
+  /// True when a kyuuklarin animation has been triggered.
+  bool get isKyuuklarin => _kyuuklarin;
 
   late final Map<String, double> _parameters;
 
@@ -48,7 +53,8 @@ class MascotController extends ChangeNotifier {
   MascotController._fromDir(String dir, {String? modelsDir, String? model})
       : _signalPath = '$dir/mascot_speaking',
         _listeningPath = '$dir/mascot_listening',
-        _dismissPath = '$dir/mascot_dismiss' {
+        _dismissPath = '$dir/mascot_dismiss',
+        _kyuuklarinPath = '$dir/mascot_kyuuklarin' {
     _modelConfig = ModelConfig.fromEnvironment(
       modelsDir: modelsDir,
       model: model,
@@ -61,7 +67,8 @@ class MascotController extends ChangeNotifier {
   @visibleForTesting
   MascotController.withConfig(this._signalPath, ModelConfig config)
       : _listeningPath = '${File(_signalPath).parent.path}/mascot_listening',
-        _dismissPath = '${File(_signalPath).parent.path}/mascot_dismiss' {
+        _dismissPath = '${File(_signalPath).parent.path}/mascot_dismiss',
+        _kyuuklarinPath = '${File(_signalPath).parent.path}/mascot_kyuuklarin' {
     _modelConfig = config;
     _parameters = Map<String, double>.from(_modelConfig.defaultParameters);
     _setEmotion(null); // Apply idle emotion
@@ -92,6 +99,20 @@ class MascotController extends ChangeNotifier {
       _dismissed = true;
       notifyListeners();
       return;
+    }
+
+    // Check kyuuklarin signal (one-shot: consume and notify)
+    final kyuuFile = File(_kyuuklarinPath);
+    if (kyuuFile.existsSync()) {
+      try {
+        kyuuFile.deleteSync();
+      } catch (_) {}
+      _kyuuklarin = true;
+      notifyListeners();
+      // Reset after widget handles it
+      Future.delayed(const Duration(milliseconds: 50), () {
+        _kyuuklarin = false;
+      });
     }
 
     // Skip signal file polling while a direct expression is active
@@ -255,7 +276,7 @@ class MascotController extends ChangeNotifier {
 
   /// Remove stale signal files on shutdown.
   void _cleanup() {
-    for (final path in [_signalPath, _listeningPath, _dismissPath]) {
+    for (final path in [_signalPath, _listeningPath, _dismissPath, _kyuuklarinPath]) {
       try {
         final file = File(path);
         if (file.existsSync()) file.deleteSync();

--- a/mascot/lib/mascot_widget.dart
+++ b/mascot/lib/mascot_widget.dart
@@ -49,6 +49,7 @@ class _MascotWidgetState extends State<MascotWidget>
   late final AnimationController _jumpController;
   late final Animation<double> _jumpAnimation;
   late final AnimationController _dismissController;
+  late final AnimationController _kyuuklaController;
   late final ExpressionService _expressionService;
   bool _showBubble = false;
   String _bubbleText = '';
@@ -81,6 +82,10 @@ class _MascotWidgetState extends State<MascotWidget>
     _dismissController = AnimationController(
       vsync: this,
       duration: const Duration(milliseconds: 300),
+    );
+    _kyuuklaController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1500),
     );
     _expressionService = ExpressionService(_controller);
     _expressionService.addListener(_onBubblesChanged);
@@ -188,6 +193,16 @@ class _MascotWidgetState extends State<MascotWidget>
   }
 
   void _onControllerChanged() {
+    // Handle kyuuklarin signal: play spin animation
+    if (_controller.isKyuuklarin && !_kyuuklaController.isAnimating) {
+      _controller.showExpression('Singing', 'きゅうくらりん♪');
+      _kyuuklaController.forward(from: 0).then((_) {
+        if (mounted) {
+          _controller.hideExpression();
+        }
+      });
+    }
+
     // Handle dismiss signal: play "pop" animation then close/notify
     if (_controller.isDismissed && !_dismissController.isAnimating) {
       _dismissController.forward().then((_) {
@@ -279,6 +294,7 @@ class _MascotWidgetState extends State<MascotWidget>
     _fadeController.dispose();
     _jumpController.dispose();
     _dismissController.dispose();
+    _kyuuklaController.dispose();
     _puppetController?.dispose();
     super.dispose();
   }
@@ -354,8 +370,31 @@ class _MascotWidgetState extends State<MascotWidget>
                         onPanEnd: _isWander
                             ? (details) => _wander!.endDrag()
                             : null,
-                        child: _buildWanderWrapper(
-                          child: _buildCharacter(),
+                        child: AnimatedBuilder(
+                          animation: _kyuuklaController,
+                          builder: (context, child) {
+                            if (!_kyuuklaController.isAnimating) {
+                              return child!;
+                            }
+                            final t = _kyuuklaController.value;
+                            // Spin 2 full rotations with ease-out
+                            final angle = t * 4 * math.pi *
+                                Curves.easeOut.transform(1 - (1 - t).abs());
+                            // Scale: grow slightly then return
+                            final scale = 1.0 + 0.2 * math.sin(t * math.pi);
+                            return Transform(
+                              alignment: Alignment.bottomCenter,
+                              transform: Matrix4.identity()
+                                ..translate(charW / 2, charH * 0.7)
+                                ..rotateZ(angle)
+                                ..scale(scale)
+                                ..translate(-charW / 2, -charH * 0.7),
+                              child: child,
+                            );
+                          },
+                          child: _buildWanderWrapper(
+                            child: _buildCharacter(),
+                          ),
                         ),
                       ),
                     ),


### PR DESCRIPTION
## Summary
- `/kyuuklarin` スキルでマスコットがくるくる回転するアニメーション
- シグナルファイル(`mascot_kyuuklarin`)経由でトリガー
- 1.5秒の回転(2回転)＋スケーリングエフェクト後に元に戻る
- Singing表情＋「きゅうくらりん♪」吹き出し付き

## Test plan
- [ ] `/kyuuklarin` コマンドでマスコットが回転する
- [ ] 回転後に通常状態に戻る
- [ ] 回転中にSinging表情と吹き出しが表示される
- [ ] ワンダーモードでも動作する

Fixes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)