### PR TITLE
feat: show custom close button on macOS

### DIFF
--- a/mascot/lib/main.dart
+++ b/mascot/lib/main.dart
@@ -78,10 +78,9 @@ void main(List<String> args) async {
     backgroundColor: Colors.transparent,
     titleBarStyle:
         Platform.isWindows ? TitleBarStyle.normal : TitleBarStyle.hidden,
-    // Hide traffic light buttons in wander mode. Must be set here (not in
-    // Swift awakeFromNib) because window_manager's setTitleBarStyle
-    // force-unwraps standardWindowButton(.closeButton) superview.
-    windowButtonVisibility: !config.wander,
+    // Hide native traffic light buttons — use custom close button instead.
+    // Wander mode also hides them (child mascots are closed by parent).
+    windowButtonVisibility: false,
     skipTaskbar: false,
     alwaysOnTop: true,
   );

--- a/mascot/lib/mascot_widget.dart
+++ b/mascot/lib/mascot_widget.dart
@@ -452,7 +452,7 @@ class _MascotWidgetState extends State<MascotWidget>
                               showTail: i == 0,
                             ),
                           ),
-                  if (io.Platform.isWindows && !_isWander)
+                  if (!_isWander)
                     Positioned(
                       top: _closeBtnTop,
                       left: _closeBtnLeft,


### PR DESCRIPTION
## Summary
- Show the same custom close button (×) on macOS that Windows already has
- Hide native macOS traffic light buttons (hard to find on borderless transparent window)
- Wander mode (child mascots) still has no close button — closed by parent

## Test plan
- [x] L1: `flutter test` — 62 tests pass
- [x] L2: `flutter build macos` — builds successfully
- [x] L3: Launched on macOS, confirmed close button visible and functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)