### PR TITLE
fix: dismissed swarm entity sprite persists on screen

### DIFF
--- a/mascot/lib/swarm/signal_monitor.dart
+++ b/mascot/lib/swarm/signal_monitor.dart
@@ -44,7 +44,9 @@ class SignalMonitor {
   }
 
   void _scan(List<MascotEntity> entities) {
-    for (final e in entities) {
+    // Iterate a snapshot: _checkDismiss may remove entities from the live list
+    // via the onDismiss callback, which would cause ConcurrentModificationError.
+    for (final e in List.of(entities)) {
       if (e.dismissed) continue;
       _checkTts(e);
       _checkDismiss(e);

--- a/mascot/lib/swarm/swarm_simulation.dart
+++ b/mascot/lib/swarm/swarm_simulation.dart
@@ -77,6 +77,10 @@ class SwarmSimulation extends ChangeNotifier {
 
   void removeEntity(MascotEntity entity) {
     entities.remove(entity);
+    // Trigger one final repaint so the painter clears the removed sprite.
+    // Without this, _onTick skips notifyListeners() when the list is empty,
+    // leaving the last frame (with the stale sprite) visible forever.
+    notifyListeners();
   }
 
   void _onTick(Duration elapsed) {


### PR DESCRIPTION
## Summary
- `SwarmSimulation.removeEntity()` now calls `notifyListeners()` to trigger a final repaint after removal, fixing stale sprites staying visible when the entity list becomes empty
- `SignalMonitor._scan()` iterates a snapshot (`List.of()`) to prevent `ConcurrentModificationError` when `onDismiss` removes entities during iteration

## Test plan
- [x] L1: `flutter test` — 62/62 passed
- [x] L2: `flutter build macos` — success
- [x] L3: Spawned child mascot via Task tool, confirmed it appeared and dismissed correctly after task completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)