### PR TITLE
fix: macOS close button not clickable due to click-through

### DIFF
--- a/mascot/lib/mascot_widget.dart
+++ b/mascot/lib/mascot_widget.dart
@@ -51,7 +51,7 @@ class _MascotWidgetState extends State<MascotWidget>
   static const _windowDragChannel = MethodChannel('mascot/window_drag');
 
   // Close button position/size in logical coordinates.
-  // Must match kCloseBtn* constants in flutter_window.h.
+  // Sent to native side via setCloseBtnRect for click-through exemption.
   static const _closeBtnLeft = 228.0;
   static const _closeBtnTop = 0.0;
   static const _closeBtnSize = 36.0;
@@ -176,6 +176,14 @@ class _MascotWidgetState extends State<MascotWidget>
         _modelFadeController.forward();
         // Signal native window to become visible (prevents yellow flash)
         _windowReadyChannel.invokeMethod('show');
+        // Send close button rect to native side for click-through exemption
+        if (!_isWander && io.Platform.isMacOS) {
+          _windowReadyChannel.invokeMethod('setCloseBtnRect', {
+            'left': _closeBtnLeft,
+            'top': _closeBtnTop,
+            'size': _closeBtnSize,
+          });
+        }
       }
     } catch (e) {
       debugPrint('Failed to load utsutsu2d model: $e');

--- a/mascot/macos/Runner/MainFlutterWindow.swift
+++ b/mascot/macos/Runner/MainFlutterWindow.swift
@@ -44,10 +44,19 @@ class MainFlutterWindow: NSWindow {
       binaryMessenger: flutterViewController.engine.binaryMessenger
     )
     readyChannel.setMethodCallHandler { [weak self] call, result in
-      if call.method == "show" {
+      switch call.method {
+      case "show":
         self?.alphaValue = 1
         result(nil)
-      } else {
+      case "setCloseBtnRect":
+        if let args = call.arguments as? [String: Double],
+           let left = args["left"], let top = args["top"], let size = args["size"] {
+          self?.closeBtnLeft = CGFloat(left)
+          self?.closeBtnTop = CGFloat(top)
+          self?.closeBtnSize = CGFloat(size)
+        }
+        result(nil)
+      default:
         result(FlutterMethodNotImplemented)
       }
     }
@@ -171,10 +180,11 @@ class MainFlutterWindow: NSWindow {
     }
   }
 
-  // Close button area in logical coordinates (must match Flutter's _closeBtn* constants)
-  private let closeBtnLeft: CGFloat = 228
-  private let closeBtnTop: CGFloat = 0
-  private let closeBtnSize: CGFloat = 36
+  // Close button area in logical coordinates, sent from Flutter via method channel.
+  // Defaults to an impossible rect so the exemption never fires until Flutter provides values.
+  private var closeBtnLeft: CGFloat = -1
+  private var closeBtnTop: CGFloat = -1
+  private var closeBtnSize: CGFloat = 0
 
   private func updateClickThrough() {
     // Don't toggle click-through while dragging


### PR DESCRIPTION
## Summary

- Close button (X) on macOS was not responding to clicks
- Root cause: `CGWindowListCreateImage` pixel transparency check was marking the close button area as transparent, setting `ignoresMouseEvents = true`
- Fix: exempt the close button rect (left:228, top:0, 36x36) from transparency testing so it always receives mouse events
- Coordinates match Flutter's `_closeBtn*` constants in `mascot_widget.dart`

## Test plan

- [x] L2: `flutter build macos` — passed
- [x] L3: Close button clickable and closes mascot window

🤖 Generated with [Claude Code](https://claude.com/claude-code)