### PR TITLE
fix: child mascot dismiss and spawn signal reliability

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,28 +1,3 @@
 {
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Task",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash -c 'python3 ~/.claude/hooks/task_spawn_hook.py'",
-            "timeout": 5000
-          }
-        ]
-      }
-    ],
-    "PostToolUse": [
-      {
-        "matcher": "Task",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash -c 'python3 ~/.claude/hooks/task_dismiss_hook.py'",
-            "timeout": 5000
-          }
-        ]
-      }
-    ]
-  }
+  "hooks": {}
 }

--- a/mascot/lib/main.dart
+++ b/mascot/lib/main.dart
@@ -459,35 +459,33 @@ class _MascotAppState extends State<MascotApp> with WindowListener {
     final dir = Directory(signalDir);
     if (!dir.existsSync()) dir.createSync(recursive: true);
 
-    // On Windows, Directory.watch() starts successfully but may not deliver
-    // FileSystemEvent.create events reliably. Always use polling there.
-    if (Platform.isWindows) {
-      _startSpawnPolling();
-      return;
-    }
+    // Always use polling as the primary mechanism — FSEvents (macOS) and
+    // Directory.watch() on Windows are unreliable for detecting files
+    // created by external processes in ~/.claude/.
+    _startSpawnPolling();
 
-    try {
-      _spawnWatcher = dir
-          .watch(events: FileSystemEvent.create | FileSystemEvent.modify)
-          .listen((event) {
-        if (event.path.contains('spawn_child')) {
-          _checkSpawnSignals();
-        }
-        if (event.path.endsWith('/cutin') || event.path.endsWith(r'\cutin')) {
-          _checkCutInSignal();
-        }
-      }, onError: (_) {
-        // Fallback to polling on watch error
-        _spawnWatcher?.cancel();
-        _spawnWatcher = null;
-        _startSpawnPolling();
-      });
-    } catch (_) {
-      _startSpawnPolling();
+    // Also set up FSEvents/inotify as a fast-path on non-Windows platforms.
+    if (!Platform.isWindows) {
+      try {
+        _spawnWatcher = dir
+            .watch(events: FileSystemEvent.create | FileSystemEvent.modify)
+            .listen((event) {
+          if (event.path.contains('spawn_child')) {
+            _checkSpawnSignals();
+          }
+          if (event.path.endsWith('/cutin') || event.path.endsWith(r'\cutin')) {
+            _checkCutInSignal();
+          }
+        }, onError: (_) {
+          _spawnWatcher?.cancel();
+          _spawnWatcher = null;
+        });
+      } catch (_) {
+        // Polling is already running, ignore watch failure
+      }
     }
 
     // Check for signals that were written before the watcher was ready
-    // (e.g. left over from a crash, or written during startup)
     _checkSpawnSignals();
     _checkCutInSignal();
   }


### PR DESCRIPTION
## Summary

- **Fix duplicate Task hooks**: Remove Task spawn/dismiss hooks from project `.claude/settings.json` — they were already registered in global `~/.claude/settings.json`, causing double-firing (two spawn signals per subagent, only one dismiss)
- **Fix FSEvents unreliability**: Always run 200ms polling alongside FSEvents/inotify watcher. FSEvents on macOS silently fails to deliver create events for files in `~/.claude/`, causing spawn signals to go unprocessed until app restart

## Test plan

- [x] Build `flutter build macos` succeeds
- [x] Launch mascot, send subagent task → child mascot appears in swarm overlay
- [x] After subagent completes → child mascot disappears (dismiss works)
- [x] Spawn signal files are consumed (no stale `spawn_child_*` files)
- [x] Task directories cleaned up after dismiss

🤖 Generated with [Claude Code](https://claude.com/claude-code)