### PR TITLE
feat: payment request notification + Linux Flutter setup

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -64,6 +64,30 @@ git tag v0.XX feature/win && git push origin v0.XX
 `~/.claude/utsutsu-code/` に置かれる:
 - `mascot_speaking` — TTSフックが書き込み、マスコットが読む（JSON: message + emotion）
 - `mascot_listening` — 音声入力が書き込み、マスコットが読む
+- `payment_request` — リミット通知フックが書き込み、マスコットが課金をお願いする（ワンショット）
+
+### 課金お願い通知（payment_request）
+
+クロードのリミットが近づいたときに、つくよみちゃんが困り顔で課金をお願いする。
+
+```bash
+# 直接トリガー
+python3 .claude/hooks/payment_request.py --message "リミットが近づいてます…"
+
+# 環境変数で自動判定（80%以上で発火）
+CLAUDE_USAGE_PERCENT=85 python3 .claude/hooks/payment_request.py
+
+# しきい値を変更
+python3 .claude/hooks/payment_request.py --check-percent 90
+
+# シグナルクリア
+python3 .claude/hooks/payment_request.py --clear
+```
+
+- シグナルファイル: `~/.claude/utsutsu-code/payment_request`
+- 感情: Trouble（困り顔）
+- ワンショット: 一度表示したら再トリガーしない（マスコット再起動までリセットされない）
+- 発話中はスキップ（通常の発話を妨げない）
 
 ## ファイル配置
 
@@ -93,10 +117,30 @@ cd mascot && flutter test
 ### L2: ビルド確認
 
 ```bash
-cd mascot && flutter build macos
+cd mascot && flutter build macos   # macOS
+cd mascot && flutter build linux   # Linux（xvfb-run 不要）
 ```
 
 - コンパイルエラーがないことを確認
+
+### リナックステスト環境セットアップ
+
+ヘッドレス環境（CI、リモートサーバー等）でフラッターテスト・ビルドを行うためのセットアップ。
+
+```bash
+# 一括セットアップ（フラッター SDK + 依存パッケージ）
+bash scripts/setup_flutter_linux.sh
+
+# 手動セットアップ
+sudo apt-get install -y xvfb libgtk-3-dev clang cmake ninja-build pkg-config libgl1-mesa-dev
+# フラッター SDK は ~/flutter にインストール（バージョン 3.38.7 / ダート 3.10.7）
+export PATH="$HOME/flutter/bin:$PATH"
+flutter config --enable-linux-desktop
+```
+
+- L1（ユニットテスト）はディスプレイ不要: `flutter test`
+- L2（ビルド）は `libgtk-3-dev` が必要: `flutter build linux`
+- `xvfb-run` はビルド時にディスプレイが必要な場合のみ使用
 
 ### L3: 実行テスト（UI変更時は必須）
 

--- a/.claude/hooks/payment_request.py
+++ b/.claude/hooks/payment_request.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Payment request hook for mascot TTS.
+
+Monitors Claude Code usage/limit signals and writes a payment_request
+signal file so the mascot can ask the user to upgrade/pay.
+
+This hook is designed to be called from Claude Code's hook system
+when usage limits are approaching (e.g., on a "Stop" or "Notification"
+event that includes limit information).
+
+Usage:
+  python3 .claude/hooks/payment_request.py
+  python3 .claude/hooks/payment_request.py --check-percent 80
+  python3 .claude/hooks/payment_request.py --message "カスタムメッセージ"
+  python3 .claude/hooks/payment_request.py --clear
+
+Environment:
+  CLAUDE_USAGE_PERCENT  - Current usage percentage (0-100)
+  CLAUDE_USAGE_LIMIT    - Whether limit is approaching ("true"/"false")
+"""
+
+import json
+import os
+import random
+import sys
+from pathlib import Path
+
+SIGNAL_DIR = os.path.expanduser("~/.claude/utsutsu-code")
+PAYMENT_REQUEST_FILE = os.path.join(SIGNAL_DIR, "payment_request")
+
+# Default threshold: trigger at 80% usage
+DEFAULT_THRESHOLD = 80
+
+PAYMENT_PHRASES = [
+    "リミットが近づいてます…課金お願いします！",
+    "もうすぐ使えなくなっちゃいます…",
+    "あの…課金していただけると嬉しいです…",
+    "リミット間近です、プランの確認お願いします！",
+    "このままだと止まっちゃいます…！",
+]
+
+
+def write_payment_request(message=None, emotion="Trouble"):
+    """Write the payment_request signal file."""
+    os.makedirs(SIGNAL_DIR, exist_ok=True)
+    if message is None:
+        message = random.choice(PAYMENT_PHRASES)
+    signal = json.dumps({
+        "version": "1",
+        "type": "mascot.payment_request",
+        "payload": {
+            "message": message,
+            "emotion": emotion,
+        },
+    })
+    Path(PAYMENT_REQUEST_FILE).write_text(signal, encoding="utf-8")
+    return message
+
+
+def clear_payment_request():
+    """Remove the payment_request signal file."""
+    try:
+        os.unlink(PAYMENT_REQUEST_FILE)
+    except OSError:
+        pass
+
+
+def should_trigger(threshold=DEFAULT_THRESHOLD):
+    """Check if usage limit conditions are met.
+
+    Returns True if:
+    - CLAUDE_USAGE_LIMIT env var is "true", OR
+    - CLAUDE_USAGE_PERCENT >= threshold
+    """
+    limit_flag = os.environ.get("CLAUDE_USAGE_LIMIT", "").lower()
+    if limit_flag == "true":
+        return True
+
+    try:
+        percent = int(os.environ.get("CLAUDE_USAGE_PERCENT", "0"))
+        return percent >= threshold
+    except (ValueError, TypeError):
+        return False
+
+
+def main():
+    argv = sys.argv[1:]
+    threshold = DEFAULT_THRESHOLD
+    message = None
+    clear = False
+
+    i = 0
+    while i < len(argv):
+        if argv[i] == "--check-percent" and i + 1 < len(argv):
+            threshold = int(argv[i + 1])
+            i += 2
+        elif argv[i] == "--message" and i + 1 < len(argv):
+            message = argv[i + 1]
+            i += 2
+        elif argv[i] == "--clear":
+            clear = True
+            i += 1
+        else:
+            # Treat remaining args as message
+            message = " ".join(argv[i:])
+            break
+
+    if clear:
+        clear_payment_request()
+        print(json.dumps({"status": "cleared"}))
+        return
+
+    # If called with explicit message, always trigger
+    if message:
+        used_message = write_payment_request(message=message)
+        print(json.dumps({"status": "triggered", "message": used_message}))
+        return
+
+    # Otherwise, check if we should trigger based on usage
+    if should_trigger(threshold):
+        used_message = write_payment_request()
+        print(json.dumps({"status": "triggered", "message": used_message}))
+    else:
+        print(json.dumps({"status": "skipped", "reason": "below_threshold"}))
+
+
+if __name__ == "__main__":
+    main()

--- a/mascot/.metadata
+++ b/mascot/.metadata
@@ -15,7 +15,7 @@ migration:
     - platform: root
       create_revision: 3b62efc2a3da49882f43c372e0bc53daef7295a6
       base_revision: 3b62efc2a3da49882f43c372e0bc53daef7295a6
-    - platform: macos
+    - platform: linux
       create_revision: 3b62efc2a3da49882f43c372e0bc53daef7295a6
       base_revision: 3b62efc2a3da49882f43c372e0bc53daef7295a6
 

--- a/mascot/config/emotions.toml
+++ b/mascot/config/emotions.toml
@@ -124,6 +124,18 @@ EyeType = 0.333          # SlightlyNarrow
 MouthType = 0.571        # OpenMedium
 CheekType = 0.333        # Blush
 
+# ── Payment Request (Limit Warning) ─────────────────────────
+[payment_request]
+description = "Phrases used when Claude's usage limit is approaching"
+emotion = "Trouble"
+phrases = [
+  "リミットが近づいてます…課金お願いします！",
+  "もうすぐ使えなくなっちゃいます…",
+  "あの…課金していただけると嬉しいです…",
+  "リミット間近です、プランの確認お願いします！",
+  "このままだと止まっちゃいます…！",
+]
+
 # ── Mouth Animation During Speech ────────────────────────────
 [mouth_animation]
 # Blend Shape Model: toggle MouthOpen 0↔1 every 150ms

--- a/mascot/lib/mascot_controller.dart
+++ b/mascot/lib/mascot_controller.dart
@@ -10,18 +10,23 @@ class MascotController extends ChangeNotifier {
   final String _signalPath;
   final String _listeningPath;
   final String _dismissPath;
+  final String _paymentRequestPath;
   late final ModelConfig _modelConfig;
 
   bool _isSpeaking = false;
   bool _isListening = false;
   bool _directExpression = false;
   bool _dismissed = false;
+  bool _paymentRequested = false;
   String _message = '';
   String? _currentEmotion;
   Map<String, double> _wanderOverrides = {};
 
   /// True when a dismiss signal has been received.
   bool get isDismissed => _dismissed;
+
+  /// True when a payment/limit request signal has been received.
+  bool get isPaymentRequested => _paymentRequested;
 
   late final Map<String, double> _parameters;
 
@@ -58,6 +63,7 @@ class MascotController extends ChangeNotifier {
       : _signalPath = '$dir/mascot_speaking',
         _listeningPath = '$dir/mascot_listening',
         _dismissPath = '$dir/mascot_dismiss',
+        _paymentRequestPath = '$dir/payment_request',
         _pollIntervalMs = pollIntervalMs,
         _mouthAnimationMs = mouthAnimationMs {
     _modelConfig = ModelConfig.fromEnvironment(
@@ -73,6 +79,7 @@ class MascotController extends ChangeNotifier {
   MascotController.withConfig(this._signalPath, ModelConfig config, {int pollIntervalMs = 100})
       : _listeningPath = '${File(_signalPath).parent.path}/mascot_listening',
         _dismissPath = '${File(_signalPath).parent.path}/mascot_dismiss',
+        _paymentRequestPath = '${File(_signalPath).parent.path}/payment_request',
         _pollIntervalMs = pollIntervalMs,
         _mouthAnimationMs = 150 {
     _modelConfig = config;
@@ -107,6 +114,25 @@ class MascotController extends ChangeNotifier {
       return;
     }
 
+    // Check payment request signal (one-shot: consume file on detection)
+    if (!_paymentRequested && !_isSpeaking) {
+      final paymentFile = File(_paymentRequestPath);
+      if (paymentFile.existsSync()) {
+        _paymentRequested = true;
+        try {
+          final content = paymentFile.readAsStringSync().trim();
+          _parseSignalContent(content);
+        } catch (_) {
+          _message = '';
+          _setEmotion('Trouble');
+        }
+        _isSpeaking = true;
+        _startMouthAnimation();
+        notifyListeners();
+        return;
+      }
+    }
+
     // Skip signal file polling while a direct expression is active
     if (_directExpression) return;
 
@@ -122,7 +148,7 @@ class MascotController extends ChangeNotifier {
         _setEmotion(null);
       }
       _startMouthAnimation();
-    } else if (!speaking && _isSpeaking) {
+    } else if (!speaking && _isSpeaking && !_paymentRequested) {
       _isSpeaking = false;
       _stopMouthAnimation();
       _setEmotion(null);
@@ -279,7 +305,7 @@ class MascotController extends ChangeNotifier {
 
   /// Remove stale signal files on shutdown.
   void _cleanup() {
-    for (final path in [_signalPath, _listeningPath, _dismissPath]) {
+    for (final path in [_signalPath, _listeningPath, _dismissPath, _paymentRequestPath]) {
       try {
         final file = File(path);
         if (file.existsSync()) file.deleteSync();

--- a/mascot/linux/.gitignore
+++ b/mascot/linux/.gitignore
@@ -1,0 +1,1 @@
+flutter/ephemeral

--- a/mascot/linux/CMakeLists.txt
+++ b/mascot/linux/CMakeLists.txt
@@ -1,0 +1,128 @@
+# Project-level configuration.
+cmake_minimum_required(VERSION 3.13)
+project(runner LANGUAGES CXX)
+
+# The name of the executable created for the application. Change this to change
+# the on-disk name of your application.
+set(BINARY_NAME "mascot")
+# The unique GTK application identifier for this application. See:
+# https://wiki.gnome.org/HowDoI/ChooseApplicationID
+set(APPLICATION_ID "com.example.mascot")
+
+# Explicitly opt in to modern CMake behaviors to avoid warnings with recent
+# versions of CMake.
+cmake_policy(SET CMP0063 NEW)
+
+# Load bundled libraries from the lib/ directory relative to the binary.
+set(CMAKE_INSTALL_RPATH "$ORIGIN/lib")
+
+# Root filesystem for cross-building.
+if(FLUTTER_TARGET_PLATFORM_SYSROOT)
+  set(CMAKE_SYSROOT ${FLUTTER_TARGET_PLATFORM_SYSROOT})
+  set(CMAKE_FIND_ROOT_PATH ${CMAKE_SYSROOT})
+  set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+  set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+  set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+  set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+endif()
+
+# Define build configuration options.
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE "Debug" CACHE
+    STRING "Flutter build mode" FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Profile" "Release")
+endif()
+
+# Compilation settings that should be applied to most targets.
+#
+# Be cautious about adding new options here, as plugins use this function by
+# default. In most cases, you should add new options to specific targets instead
+# of modifying this function.
+function(APPLY_STANDARD_SETTINGS TARGET)
+  target_compile_features(${TARGET} PUBLIC cxx_std_14)
+  target_compile_options(${TARGET} PRIVATE -Wall -Werror)
+  target_compile_options(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:-O3>")
+  target_compile_definitions(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:NDEBUG>")
+endfunction()
+
+# Flutter library and tool build rules.
+set(FLUTTER_MANAGED_DIR "${CMAKE_CURRENT_SOURCE_DIR}/flutter")
+add_subdirectory(${FLUTTER_MANAGED_DIR})
+
+# System-level dependencies.
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
+
+# Application build; see runner/CMakeLists.txt.
+add_subdirectory("runner")
+
+# Run the Flutter tool portions of the build. This must not be removed.
+add_dependencies(${BINARY_NAME} flutter_assemble)
+
+# Only the install-generated bundle's copy of the executable will launch
+# correctly, since the resources must in the right relative locations. To avoid
+# people trying to run the unbundled copy, put it in a subdirectory instead of
+# the default top-level location.
+set_target_properties(${BINARY_NAME}
+  PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/intermediates_do_not_run"
+)
+
+
+# Generated plugin build rules, which manage building the plugins and adding
+# them to the application.
+include(flutter/generated_plugins.cmake)
+
+
+# === Installation ===
+# By default, "installing" just makes a relocatable bundle in the build
+# directory.
+set(BUILD_BUNDLE_DIR "${PROJECT_BINARY_DIR}/bundle")
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(CMAKE_INSTALL_PREFIX "${BUILD_BUNDLE_DIR}" CACHE PATH "..." FORCE)
+endif()
+
+# Start with a clean build bundle directory every time.
+install(CODE "
+  file(REMOVE_RECURSE \"${BUILD_BUNDLE_DIR}/\")
+  " COMPONENT Runtime)
+
+set(INSTALL_BUNDLE_DATA_DIR "${CMAKE_INSTALL_PREFIX}/data")
+set(INSTALL_BUNDLE_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib")
+
+install(TARGETS ${BINARY_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}"
+  COMPONENT Runtime)
+
+install(FILES "${FLUTTER_ICU_DATA_FILE}" DESTINATION "${INSTALL_BUNDLE_DATA_DIR}"
+  COMPONENT Runtime)
+
+install(FILES "${FLUTTER_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+  COMPONENT Runtime)
+
+foreach(bundled_library ${PLUGIN_BUNDLED_LIBRARIES})
+  install(FILES "${bundled_library}"
+    DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endforeach(bundled_library)
+
+# Copy the native assets provided by the build.dart from all packages.
+set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/linux/")
+install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+   COMPONENT Runtime)
+
+# Fully re-copy the assets directory on each build to avoid having stale files
+# from a previous install.
+set(FLUTTER_ASSET_DIR_NAME "flutter_assets")
+install(CODE "
+  file(REMOVE_RECURSE \"${INSTALL_BUNDLE_DATA_DIR}/${FLUTTER_ASSET_DIR_NAME}\")
+  " COMPONENT Runtime)
+install(DIRECTORY "${PROJECT_BUILD_DIR}/${FLUTTER_ASSET_DIR_NAME}"
+  DESTINATION "${INSTALL_BUNDLE_DATA_DIR}" COMPONENT Runtime)
+
+# Install the AOT library on non-Debug builds only.
+if(NOT CMAKE_BUILD_TYPE MATCHES "Debug")
+  install(FILES "${AOT_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endif()

--- a/mascot/linux/flutter/CMakeLists.txt
+++ b/mascot/linux/flutter/CMakeLists.txt
@@ -1,0 +1,88 @@
+# This file controls Flutter-level build steps. It should not be edited.
+cmake_minimum_required(VERSION 3.10)
+
+set(EPHEMERAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ephemeral")
+
+# Configuration provided via flutter tool.
+include(${EPHEMERAL_DIR}/generated_config.cmake)
+
+# TODO: Move the rest of this into files in ephemeral. See
+# https://github.com/flutter/flutter/issues/57146.
+
+# Serves the same purpose as list(TRANSFORM ... PREPEND ...),
+# which isn't available in 3.10.
+function(list_prepend LIST_NAME PREFIX)
+    set(NEW_LIST "")
+    foreach(element ${${LIST_NAME}})
+        list(APPEND NEW_LIST "${PREFIX}${element}")
+    endforeach(element)
+    set(${LIST_NAME} "${NEW_LIST}" PARENT_SCOPE)
+endfunction()
+
+# === Flutter Library ===
+# System-level dependencies.
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
+pkg_check_modules(GLIB REQUIRED IMPORTED_TARGET glib-2.0)
+pkg_check_modules(GIO REQUIRED IMPORTED_TARGET gio-2.0)
+
+set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/libflutter_linux_gtk.so")
+
+# Published to parent scope for install step.
+set(FLUTTER_LIBRARY ${FLUTTER_LIBRARY} PARENT_SCOPE)
+set(FLUTTER_ICU_DATA_FILE "${EPHEMERAL_DIR}/icudtl.dat" PARENT_SCOPE)
+set(PROJECT_BUILD_DIR "${PROJECT_DIR}/build/" PARENT_SCOPE)
+set(AOT_LIBRARY "${PROJECT_DIR}/build/lib/libapp.so" PARENT_SCOPE)
+
+list(APPEND FLUTTER_LIBRARY_HEADERS
+  "fl_basic_message_channel.h"
+  "fl_binary_codec.h"
+  "fl_binary_messenger.h"
+  "fl_dart_project.h"
+  "fl_engine.h"
+  "fl_json_message_codec.h"
+  "fl_json_method_codec.h"
+  "fl_message_codec.h"
+  "fl_method_call.h"
+  "fl_method_channel.h"
+  "fl_method_codec.h"
+  "fl_method_response.h"
+  "fl_plugin_registrar.h"
+  "fl_plugin_registry.h"
+  "fl_standard_message_codec.h"
+  "fl_standard_method_codec.h"
+  "fl_string_codec.h"
+  "fl_value.h"
+  "fl_view.h"
+  "flutter_linux.h"
+)
+list_prepend(FLUTTER_LIBRARY_HEADERS "${EPHEMERAL_DIR}/flutter_linux/")
+add_library(flutter INTERFACE)
+target_include_directories(flutter INTERFACE
+  "${EPHEMERAL_DIR}"
+)
+target_link_libraries(flutter INTERFACE "${FLUTTER_LIBRARY}")
+target_link_libraries(flutter INTERFACE
+  PkgConfig::GTK
+  PkgConfig::GLIB
+  PkgConfig::GIO
+)
+add_dependencies(flutter flutter_assemble)
+
+# === Flutter tool backend ===
+# _phony_ is a non-existent file to force this command to run every time,
+# since currently there's no way to get a full input/output list from the
+# flutter tool.
+add_custom_command(
+  OUTPUT ${FLUTTER_LIBRARY} ${FLUTTER_LIBRARY_HEADERS}
+    ${CMAKE_CURRENT_BINARY_DIR}/_phony_
+  COMMAND ${CMAKE_COMMAND} -E env
+    ${FLUTTER_TOOL_ENVIRONMENT}
+    "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.sh"
+      ${FLUTTER_TARGET_PLATFORM} ${CMAKE_BUILD_TYPE}
+  VERBATIM
+)
+add_custom_target(flutter_assemble DEPENDS
+  "${FLUTTER_LIBRARY}"
+  ${FLUTTER_LIBRARY_HEADERS}
+)

--- a/mascot/linux/flutter/generated_plugin_registrant.cc
+++ b/mascot/linux/flutter/generated_plugin_registrant.cc
@@ -1,0 +1,19 @@
+//
+//  Generated file. Do not edit.
+//
+
+// clang-format off
+
+#include "generated_plugin_registrant.h"
+
+#include <screen_retriever/screen_retriever_plugin.h>
+#include <window_manager/window_manager_plugin.h>
+
+void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) screen_retriever_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverPlugin");
+  screen_retriever_plugin_register_with_registrar(screen_retriever_registrar);
+  g_autoptr(FlPluginRegistrar) window_manager_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "WindowManagerPlugin");
+  window_manager_plugin_register_with_registrar(window_manager_registrar);
+}

--- a/mascot/linux/flutter/generated_plugin_registrant.h
+++ b/mascot/linux/flutter/generated_plugin_registrant.h
@@ -1,0 +1,15 @@
+//
+//  Generated file. Do not edit.
+//
+
+// clang-format off
+
+#ifndef GENERATED_PLUGIN_REGISTRANT_
+#define GENERATED_PLUGIN_REGISTRANT_
+
+#include <flutter_linux/flutter_linux.h>
+
+// Registers Flutter plugins.
+void fl_register_plugins(FlPluginRegistry* registry);
+
+#endif  // GENERATED_PLUGIN_REGISTRANT_

--- a/mascot/linux/flutter/generated_plugins.cmake
+++ b/mascot/linux/flutter/generated_plugins.cmake
@@ -1,0 +1,25 @@
+#
+# Generated file, do not edit.
+#
+
+list(APPEND FLUTTER_PLUGIN_LIST
+  screen_retriever
+  window_manager
+)
+
+list(APPEND FLUTTER_FFI_PLUGIN_LIST
+)
+
+set(PLUGIN_BUNDLED_LIBRARIES)
+
+foreach(plugin ${FLUTTER_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${plugin}/linux plugins/${plugin})
+  target_link_libraries(${BINARY_NAME} PRIVATE ${plugin}_plugin)
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
+endforeach(plugin)
+
+foreach(ffi_plugin ${FLUTTER_FFI_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${ffi_plugin}/linux plugins/${ffi_plugin})
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${ffi_plugin}_bundled_libraries})
+endforeach(ffi_plugin)

--- a/mascot/linux/runner/CMakeLists.txt
+++ b/mascot/linux/runner/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.13)
+project(runner LANGUAGES CXX)
+
+# Define the application target. To change its name, change BINARY_NAME in the
+# top-level CMakeLists.txt, not the value here, or `flutter run` will no longer
+# work.
+#
+# Any new source files that you add to the application should be added here.
+add_executable(${BINARY_NAME}
+  "main.cc"
+  "my_application.cc"
+  "${FLUTTER_MANAGED_DIR}/generated_plugin_registrant.cc"
+)
+
+# Apply the standard set of build settings. This can be removed for applications
+# that need different build settings.
+apply_standard_settings(${BINARY_NAME})
+
+# Add preprocessor definitions for the application ID.
+add_definitions(-DAPPLICATION_ID="${APPLICATION_ID}")
+
+# Add dependency libraries. Add any application-specific dependencies here.
+target_link_libraries(${BINARY_NAME} PRIVATE flutter)
+target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::GTK)
+
+target_include_directories(${BINARY_NAME} PRIVATE "${CMAKE_SOURCE_DIR}")

--- a/mascot/linux/runner/main.cc
+++ b/mascot/linux/runner/main.cc
@@ -1,0 +1,6 @@
+#include "my_application.h"
+
+int main(int argc, char** argv) {
+  g_autoptr(MyApplication) app = my_application_new();
+  return g_application_run(G_APPLICATION(app), argc, argv);
+}

--- a/mascot/linux/runner/my_application.cc
+++ b/mascot/linux/runner/my_application.cc
@@ -1,0 +1,148 @@
+#include "my_application.h"
+
+#include <flutter_linux/flutter_linux.h>
+#ifdef GDK_WINDOWING_X11
+#include <gdk/gdkx.h>
+#endif
+
+#include "flutter/generated_plugin_registrant.h"
+
+struct _MyApplication {
+  GtkApplication parent_instance;
+  char** dart_entrypoint_arguments;
+};
+
+G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
+
+// Called when first Flutter frame received.
+static void first_frame_cb(MyApplication* self, FlView* view) {
+  gtk_widget_show(gtk_widget_get_toplevel(GTK_WIDGET(view)));
+}
+
+// Implements GApplication::activate.
+static void my_application_activate(GApplication* application) {
+  MyApplication* self = MY_APPLICATION(application);
+  GtkWindow* window =
+      GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
+
+  // Use a header bar when running in GNOME as this is the common style used
+  // by applications and is the setup most users will be using (e.g. Ubuntu
+  // desktop).
+  // If running on X and not using GNOME then just use a traditional title bar
+  // in case the window manager does more exotic layout, e.g. tiling.
+  // If running on Wayland assume the header bar will work (may need changing
+  // if future cases occur).
+  gboolean use_header_bar = TRUE;
+#ifdef GDK_WINDOWING_X11
+  GdkScreen* screen = gtk_window_get_screen(window);
+  if (GDK_IS_X11_SCREEN(screen)) {
+    const gchar* wm_name = gdk_x11_screen_get_window_manager_name(screen);
+    if (g_strcmp0(wm_name, "GNOME Shell") != 0) {
+      use_header_bar = FALSE;
+    }
+  }
+#endif
+  if (use_header_bar) {
+    GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
+    gtk_widget_show(GTK_WIDGET(header_bar));
+    gtk_header_bar_set_title(header_bar, "mascot");
+    gtk_header_bar_set_show_close_button(header_bar, TRUE);
+    gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
+  } else {
+    gtk_window_set_title(window, "mascot");
+  }
+
+  gtk_window_set_default_size(window, 1280, 720);
+
+  g_autoptr(FlDartProject) project = fl_dart_project_new();
+  fl_dart_project_set_dart_entrypoint_arguments(
+      project, self->dart_entrypoint_arguments);
+
+  FlView* view = fl_view_new(project);
+  GdkRGBA background_color;
+  // Background defaults to black, override it here if necessary, e.g. #00000000
+  // for transparent.
+  gdk_rgba_parse(&background_color, "#000000");
+  fl_view_set_background_color(view, &background_color);
+  gtk_widget_show(GTK_WIDGET(view));
+  gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));
+
+  // Show the window when Flutter renders.
+  // Requires the view to be realized so we can start rendering.
+  g_signal_connect_swapped(view, "first-frame", G_CALLBACK(first_frame_cb),
+                           self);
+  gtk_widget_realize(GTK_WIDGET(view));
+
+  fl_register_plugins(FL_PLUGIN_REGISTRY(view));
+
+  gtk_widget_grab_focus(GTK_WIDGET(view));
+}
+
+// Implements GApplication::local_command_line.
+static gboolean my_application_local_command_line(GApplication* application,
+                                                  gchar*** arguments,
+                                                  int* exit_status) {
+  MyApplication* self = MY_APPLICATION(application);
+  // Strip out the first argument as it is the binary name.
+  self->dart_entrypoint_arguments = g_strdupv(*arguments + 1);
+
+  g_autoptr(GError) error = nullptr;
+  if (!g_application_register(application, nullptr, &error)) {
+    g_warning("Failed to register: %s", error->message);
+    *exit_status = 1;
+    return TRUE;
+  }
+
+  g_application_activate(application);
+  *exit_status = 0;
+
+  return TRUE;
+}
+
+// Implements GApplication::startup.
+static void my_application_startup(GApplication* application) {
+  // MyApplication* self = MY_APPLICATION(object);
+
+  // Perform any actions required at application startup.
+
+  G_APPLICATION_CLASS(my_application_parent_class)->startup(application);
+}
+
+// Implements GApplication::shutdown.
+static void my_application_shutdown(GApplication* application) {
+  // MyApplication* self = MY_APPLICATION(object);
+
+  // Perform any actions required at application shutdown.
+
+  G_APPLICATION_CLASS(my_application_parent_class)->shutdown(application);
+}
+
+// Implements GObject::dispose.
+static void my_application_dispose(GObject* object) {
+  MyApplication* self = MY_APPLICATION(object);
+  g_clear_pointer(&self->dart_entrypoint_arguments, g_strfreev);
+  G_OBJECT_CLASS(my_application_parent_class)->dispose(object);
+}
+
+static void my_application_class_init(MyApplicationClass* klass) {
+  G_APPLICATION_CLASS(klass)->activate = my_application_activate;
+  G_APPLICATION_CLASS(klass)->local_command_line =
+      my_application_local_command_line;
+  G_APPLICATION_CLASS(klass)->startup = my_application_startup;
+  G_APPLICATION_CLASS(klass)->shutdown = my_application_shutdown;
+  G_OBJECT_CLASS(klass)->dispose = my_application_dispose;
+}
+
+static void my_application_init(MyApplication* self) {}
+
+MyApplication* my_application_new() {
+  // Set the program name to the application ID, which helps various systems
+  // like GTK and desktop environments map this running application to its
+  // corresponding .desktop file. This ensures better integration by allowing
+  // the application to be recognized beyond its binary name.
+  g_set_prgname(APPLICATION_ID);
+
+  return MY_APPLICATION(g_object_new(my_application_get_type(),
+                                     "application-id", APPLICATION_ID, "flags",
+                                     G_APPLICATION_NON_UNIQUE, nullptr));
+}

--- a/mascot/linux/runner/my_application.h
+++ b/mascot/linux/runner/my_application.h
@@ -1,0 +1,21 @@
+#ifndef FLUTTER_MY_APPLICATION_H_
+#define FLUTTER_MY_APPLICATION_H_
+
+#include <gtk/gtk.h>
+
+G_DECLARE_FINAL_TYPE(MyApplication,
+                     my_application,
+                     MY,
+                     APPLICATION,
+                     GtkApplication)
+
+/**
+ * my_application_new:
+ *
+ * Creates a new Flutter-based application.
+ *
+ * Returns: a new #MyApplication.
+ */
+MyApplication* my_application_new();
+
+#endif  // FLUTTER_MY_APPLICATION_H_

--- a/mascot/test/widget_test.dart
+++ b/mascot/test/widget_test.dart
@@ -1271,4 +1271,144 @@ width = 500.0
           reason: 'Second rename should fail since original was already claimed');
     });
   });
+
+  // ── Payment Request Signal Tests ──────────────────────────
+
+  group('Payment request signal', () {
+    late Directory signalDir;
+    late MascotController controller;
+
+    setUp(() {
+      signalDir = Directory.systemTemp.createTempSync('payment_test_');
+      File('${signalDir.path}/mascot_speaking').parent.createSync(recursive: true);
+      controller = MascotController.withConfig(
+        '${signalDir.path}/mascot_speaking',
+        _blendShapeConfig('/tmp/test'),
+      );
+    });
+
+    tearDown(() {
+      controller.dispose();
+      signalDir.deleteSync(recursive: true);
+    });
+
+    test('payment_request signal triggers speaking with Trouble emotion', () async {
+      final paymentFile = File('${signalDir.path}/payment_request');
+      final signal = jsonEncode({
+        'version': '1',
+        'type': 'mascot.payment_request',
+        'payload': {
+          'message': 'リミットが近づいてます…課金お願いします！',
+          'emotion': 'Trouble',
+        },
+      });
+      paymentFile.writeAsStringSync(signal);
+
+      await Future<void>.delayed(const Duration(milliseconds: 250));
+
+      expect(controller.isSpeaking, true);
+      expect(controller.isPaymentRequested, true);
+      expect(controller.message, 'リミットが近づいてます…課金お願いします！');
+      expect(controller.parameters['Trouble'], 1.0);
+    });
+
+    test('payment_request is one-shot (does not re-trigger)', () async {
+      final paymentFile = File('${signalDir.path}/payment_request');
+      paymentFile.writeAsStringSync(jsonEncode({
+        'version': '1',
+        'type': 'mascot.payment_request',
+        'payload': {
+          'message': 'テスト課金メッセージ',
+          'emotion': 'Trouble',
+        },
+      }));
+
+      await Future<void>.delayed(const Duration(milliseconds: 250));
+      expect(controller.isPaymentRequested, true);
+
+      // Overwrite with new content — should NOT re-trigger
+      paymentFile.writeAsStringSync(jsonEncode({
+        'version': '1',
+        'type': 'mascot.payment_request',
+        'payload': {
+          'message': '二回目のメッセージ',
+          'emotion': 'Trouble',
+        },
+      }));
+
+      await Future<void>.delayed(const Duration(milliseconds: 250));
+      // Message should still be the first one
+      expect(controller.message, 'テスト課金メッセージ');
+    });
+
+    test('payment_request does not trigger while already speaking', () async {
+      // Start speaking via normal signal first
+      File('${signalDir.path}/mascot_speaking')
+          .writeAsStringSync(jsonEncode({'message': '通常発話', 'emotion': 'Joy'}));
+      await Future<void>.delayed(const Duration(milliseconds: 250));
+      expect(controller.isSpeaking, true);
+
+      // Write payment request — should not trigger while speaking
+      File('${signalDir.path}/payment_request')
+          .writeAsStringSync(jsonEncode({
+        'version': '1',
+        'type': 'mascot.payment_request',
+        'payload': {'message': '課金お願い', 'emotion': 'Trouble'},
+      }));
+
+      await Future<void>.delayed(const Duration(milliseconds: 250));
+      expect(controller.isPaymentRequested, false);
+      expect(controller.message, '通常発話');
+    });
+
+    test('payment_request with legacy JSON format works', () async {
+      File('${signalDir.path}/payment_request')
+          .writeAsStringSync(jsonEncode({
+        'message': 'レガシー課金メッセージ',
+        'emotion': 'Trouble',
+      }));
+
+      await Future<void>.delayed(const Duration(milliseconds: 250));
+
+      expect(controller.isSpeaking, true);
+      expect(controller.isPaymentRequested, true);
+      expect(controller.message, 'レガシー課金メッセージ');
+    });
+
+    test('payment_request file is cleaned up on dispose', () async {
+      // Use a separate controller to avoid double-dispose in tearDown
+      final dir = Directory.systemTemp.createTempSync('payment_dispose_test_');
+      final c = MascotController.withConfig(
+        '${dir.path}/mascot_speaking',
+        _blendShapeConfig('/tmp/test'),
+      );
+      final paymentFile = File('${dir.path}/payment_request');
+      paymentFile.writeAsStringSync('test');
+
+      await Future<void>.delayed(const Duration(milliseconds: 250));
+
+      c.dispose();
+      expect(paymentFile.existsSync(), false);
+      dir.deleteSync(recursive: true);
+    });
+
+    test('speaking stops normally but payment_request persists after file removal', () async {
+      // Trigger payment request
+      File('${signalDir.path}/payment_request')
+          .writeAsStringSync(jsonEncode({
+        'message': '課金テスト',
+        'emotion': 'Trouble',
+      }));
+
+      await Future<void>.delayed(const Duration(milliseconds: 250));
+      expect(controller.isSpeaking, true);
+      expect(controller.isPaymentRequested, true);
+
+      // Normal signal file doesn't exist — payment_requested should prevent
+      // the speaking state from being cleared
+      await Future<void>.delayed(const Duration(milliseconds: 250));
+      expect(controller.isSpeaking, true,
+          reason: 'Payment request should keep speaking state');
+    });
+  });
 }

--- a/scripts/setup_flutter_linux.sh
+++ b/scripts/setup_flutter_linux.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Flutter Linux offscreen rendering setup for CI/headless environments.
+#
+# Installs Flutter SDK + dependencies for running unit tests and building
+# the mascot app on Linux without a display server (using xvfb).
+#
+# Usage:
+#   bash scripts/setup_flutter_linux.sh
+#
+# After setup:
+#   cd mascot && flutter test              # L1: unit tests (no display needed)
+#   cd mascot && xvfb-run flutter build linux  # L2: build check (needs xvfb)
+
+set -euo pipefail
+
+FLUTTER_VERSION="3.38.7"
+FLUTTER_DIR="${FLUTTER_DIR:-$HOME/flutter}"
+
+echo "=== Flutter Linux Setup ==="
+
+# 1. Install system dependencies
+echo "[1/4] Installing system dependencies..."
+sudo apt-get update -qq
+sudo apt-get install -y --no-install-recommends \
+  xvfb \
+  libgtk-3-dev \
+  clang cmake ninja-build pkg-config \
+  libgl1-mesa-dev \
+  2>/dev/null
+
+# 2. Install Flutter SDK
+if [ -x "$FLUTTER_DIR/bin/flutter" ]; then
+  CURRENT_VERSION=$("$FLUTTER_DIR/bin/flutter" --version 2>/dev/null | head -1 | awk '{print $2}')
+  echo "[2/4] Flutter $CURRENT_VERSION already installed at $FLUTTER_DIR"
+else
+  echo "[2/4] Installing Flutter $FLUTTER_VERSION..."
+  curl -sL "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${FLUTTER_VERSION}-stable.tar.xz" \
+    | tar xJ -C "$(dirname "$FLUTTER_DIR")"
+  git config --global --add safe.directory "$FLUTTER_DIR"
+fi
+
+export PATH="$FLUTTER_DIR/bin:$PATH"
+
+# 3. Enable Linux desktop
+echo "[3/4] Enabling Linux desktop target..."
+flutter config --enable-linux-desktop 2>/dev/null
+
+# 4. Verify
+echo "[4/4] Verifying setup..."
+flutter --version
+echo ""
+echo "=== Setup complete ==="
+echo ""
+echo "Run tests:  cd mascot && flutter test"
+echo "Build:      cd mascot && xvfb-run flutter build linux"
+echo ""
+echo "Add to PATH: export PATH=\"$FLUTTER_DIR/bin:\$PATH\""


### PR DESCRIPTION
Add payment_request signal support so the mascot asks users to
upgrade when Claude's usage limit is approaching. The mascot
detects `~/.claude/utsutsu-code/payment_request` signal files,
shows a Trouble-face expression with a cute payment plea, and
keeps the bubble visible (one-shot, no re-trigger).

Also adds:
- Linux platform support (mascot/linux/) for Flutter desktop
- setup_flutter_linux.sh for CI/headless offscreen rendering (xvfb)
- payment_request.py hook for writing limit signals
- 6 new unit tests for the payment request feature (86 total, all pass)

https://claude.ai/code/session_01SvJJ7CEkNxJeWGZNgBJWoS